### PR TITLE
Rebase to 1.2.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+
+1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
+2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
+3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
+-->
+
+**What type of PR is this?**
+> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
+>
+> /kind api-change
+> /kind bug
+> /kind cleanup
+> /kind design
+> /kind documentation
+> /kind failing-test
+> /kind feature
+> /kind flake
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+<!--
+*Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
+-->
+Fixes #
+
+**Special notes for your reviewer**:
+
+**Does this PR introduce a user-facing change?**:
+<!--
+If no, just write "NONE" in the release-note block below.
+If yes, a release note is required:
+Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
+-->
+```release-note
+
+```

--- a/CHANGELOG-1.2.md
+++ b/CHANGELOG-1.2.md
@@ -1,0 +1,7 @@
+# Changelog since v1.1.0
+
+## New Features
+
+- Support Node Driver Registrar on Windows nodes. Note Windows container images are not published and need to be manually built. ([#47](https://github.com/kubernetes-csi/node-driver-registrar/pull/47), [@ddebroy](https://github.com/ddebroy))
+
+

--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/windows/servercore:1809 as core
+
+FROM mcr.microsoft.com/windows/nanoserver:1809
+LABEL description="CSI Node driver registrar"
+
+COPY ./bin/csi-node-driver-registrar.exe /csi-node-driver-registrar.exe
+COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
+USER ContainerAdministrator
+ENTRYPOINT ["/csi-node-driver-registrar.exe"]

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/kubernetes-csi/node-driver-registrar
 COPY . .
 RUN make build

--- a/Dockerfile.openshift.rhel7
+++ b/Dockerfile.openshift.rhel7
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.11 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/kubernetes-csi/node-driver-registrar
 COPY . .
 RUN make build

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This information reflects the head of this branch.
 | ------------------------------------------------------------------------------------------ | ----------------------------------------------- | --------------- |
 | [CSI Spec v1.0.0](https://github.com/container-storage-interface/spec/releases/tag/v1.0.0) | quay.io/k8scsi/csi-node-driver-registrar        | 1.13            |
 
-For release-0.4 and below, please refer to the [node-registrar
+For release-0.4 and below, please refer to the [driver-registrar
 repository](https://github.com/kubernetes-csi/driver-registrar).
 
 ## Usage

--- a/cmd/csi-node-driver-registrar/util_linux.go
+++ b/cmd/csi-node-driver-registrar/util_linux.go
@@ -1,0 +1,27 @@
+// +build linux
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func umask(mask int) (int, error) {
+	return unix.Umask(mask), nil
+}

--- a/cmd/csi-node-driver-registrar/util_windows.go
+++ b/cmd/csi-node-driver-registrar/util_windows.go
@@ -1,0 +1,27 @@
+// +build windows
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+)
+
+func umask(mask int) (int, error) {
+	return -1, errors.New("umask not supported in Windows")
+}

--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -63,6 +63,7 @@ endif
 build-%:
 	mkdir -p bin
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$* ./cmd/$*
+	CGO_ENABLED=0 GOOS=windows go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$*.exe ./cmd/$*
 
 container-%: build-%
 	docker build -t $*:latest -f $(shell if [ -e ./cmd/$*/Dockerfile ]; then echo ./cmd/$*/Dockerfile; else echo Dockerfile; fi) --label revision=$(REV) .
@@ -118,14 +119,39 @@ test-fmt:
 	fi
 
 # This test only runs when dep >= 0.5 is installed, which is the case for the CI setup.
+# When using 'go mod', we allow the test to be skipped in the Prow CI under some special
+# circumstances, because it depends on accessing all remote repos and thus
+# running it all the time would defeat the purpose of vendoring:
+# - not handling a PR or
+# - the fabricated merge commit leaves go.mod, go.sum and vendor dir unchanged
+# - release-tools also didn't change (changing rules or Go version might lead to
+#   a different result and thus must be tested)
 .PHONY: test-vendor
 test: test-vendor
 test-vendor:
 	@ echo; echo "### $@:"
-	@ case "$$(dep version 2>/dev/null | grep 'version *:')" in \
-		*v0.[56789]*) dep check && echo "vendor up-to-date" || false;; \
-		*) echo "skipping check, dep >= 0.5 required";; \
-	esac
+	@ if [ -f Gopkg.toml ]; then \
+		echo "Repo uses 'dep' for vendoring."; \
+		case "$$(dep version 2>/dev/null | grep 'version *:')" in \
+			*v0.[56789]*) dep check && echo "vendor up-to-date" || false;; \
+			*) echo "skipping check, dep >= 0.5 required";; \
+		esac; \
+	  else \
+		echo "Repo uses 'go mod' for vendoring."; \
+		if [ "$${JOB_NAME}" ] && \
+                   ( [ "$${JOB_TYPE}" != "presubmit" ] || \
+                     [ $$(git diff "${PULL_BASE_SHA}..HEAD" -- go.mod go.sum vendor release-tools | wc -l) -eq 0 ] ); then \
+			echo "Skipping vendor check because the Prow pre-submit job does not change vendoring."; \
+		elif ! GO111MODULE=on go mod vendor; then \
+			echo "ERROR: vendor check failed."; \
+			false; \
+		elif [ $$(git status --porcelain -- vendor | wc -l) -gt 0 ]; then \
+			echo "ERROR: vendor directory *not* up-to-date, it did get modified by 'GO111MODULE=on go mod vendor':"; \
+			git status -- vendor; \
+			git diff -- vendor; \
+			false; \
+		fi; \
+	 fi;
 
 .PHONY: test-subtree
 test: test-subtree

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -52,6 +52,26 @@ configvar () {
     eval echo "\$3:" "$1=\${$1}"
 }
 
+# Takes the minor version of $CSI_PROW_KUBERNETES_VERSION and overrides it to
+# $1 if they are equal minor versions. Ignores versions that begin with
+# "release-".
+override_k8s_version () {
+    local current_minor_version
+    local override_minor_version
+
+    # Ignore: See if you can use ${variable//search/replace} instead.
+    # shellcheck disable=SC2001
+    current_minor_version="$(echo "${CSI_PROW_KUBERNETES_VERSION}" | sed -e 's/\([0-9]*\)\.\([0-9]*\).*/\1\.\2/')"
+
+    # Ignore: See if you can use ${variable//search/replace} instead.
+    # shellcheck disable=SC2001
+    override_minor_version="$(echo "${1}" | sed -e 's/\([0-9]*\)\.\([0-9]*\).*/\1\.\2/')"
+    if [ "${current_minor_version}" == "${override_minor_version}" ]; then
+      CSI_PROW_KUBERNETES_VERSION="$1"
+      echo "Overriding CSI_PROW_KUBERNETES_VERSION with $1: $CSI_PROW_KUBERNETES_VERSION"
+    fi
+}
+
 # Prints the value of a variable + version suffix, falling back to variable + "LATEST".
 get_versioned_variable () {
     local var="$1"
@@ -81,7 +101,7 @@ configvar CSI_PROW_GO_VERSION_GINKGO "${CSI_PROW_GO_VERSION_BUILD}" "Go version 
 # kind version to use. If the pre-installed version is different,
 # the desired version is downloaded from https://github.com/kubernetes-sigs/kind/releases/download/
 # (if available), otherwise it is built from source.
-configvar CSI_PROW_KIND_VERSION 0.2.1 "kind"
+configvar CSI_PROW_KIND_VERSION "v0.5.0" "kind"
 
 # ginkgo test runner version to use. If the pre-installed version is
 # different, the desired version is built from source.
@@ -106,7 +126,19 @@ configvar CSI_PROW_BUILD_JOB true "building code in repo enabled"
 # use the same settings as for "latest" Kubernetes. This works
 # as long as there are no breaking changes in Kubernetes, like
 # deprecating or changing the implementation of an alpha feature.
-configvar CSI_PROW_KUBERNETES_VERSION 1.13.3 "Kubernetes"
+configvar CSI_PROW_KUBERNETES_VERSION 1.15.3 "Kubernetes"
+
+# This is a hack to workaround the issue that each version
+# of kind currently only supports specific patch versions of
+# Kubernetes. We need to override CSI_PROW_KUBERNETES_VERSION
+# passed in by our CI/pull jobs to the versions that
+# kind v0.5.0 supports.
+#
+# If the version is prefixed with "release-", then nothing
+# is overridden.
+override_k8s_version "1.13.10"
+override_k8s_version "1.14.6"
+override_k8s_version "1.15.3"
 
 # CSI_PROW_KUBERNETES_VERSION reduced to first two version numbers and
 # with underscore (1_13 instead of 1.13.3) and in uppercase (LATEST
@@ -151,9 +183,10 @@ configvar CSI_PROW_WORK "$(mkdir -p "$GOPATH/pkg" && mktemp -d "$GOPATH/pkg/csip
 #
 # When no deploy script is found (nothing in `deploy` directory,
 # CSI_PROW_HOSTPATH_REPO=none), nothing gets deployed.
-configvar CSI_PROW_HOSTPATH_VERSION fc52d13ba07922c80555a24616a5b16480350c3f "hostpath driver" # pre-1.1.0
+configvar CSI_PROW_HOSTPATH_VERSION "v1.2.0-rc2" "hostpath driver"
 configvar CSI_PROW_HOSTPATH_REPO https://github.com/kubernetes-csi/csi-driver-host-path "hostpath repo"
 configvar CSI_PROW_DEPLOYMENT "" "deployment"
+configvar CSI_PROW_HOSTPATH_DRIVER_NAME "hostpath.csi.k8s.io" "the hostpath driver name"
 
 # If CSI_PROW_HOSTPATH_CANARY is set (typically to "canary", but also
 # "1.0-canary"), then all image versions are replaced with that
@@ -169,6 +202,7 @@ configvar CSI_PROW_HOSTPATH_CANARY "" "hostpath image"
 # CSI_PROW_E2E_REPO=none disables E2E testing.
 configvar CSI_PROW_E2E_VERSION_1_13 v1.14.0 "E2E version for Kubernetes 1.13.x" # we can't use the one from 1.13.x because it didn't have --storage.testdriver
 configvar CSI_PROW_E2E_VERSION_1_14 v1.14.0 "E2E version for Kubernetes 1.14.x"
+configvar CSI_PROW_E2E_VERSION_1_15 v1.15.0 "E2E version for Kubernetes 1.15.x"
 # TODO: add new CSI_PROW_E2E_VERSION entry for future Kubernetes releases
 configvar CSI_PROW_E2E_VERSION_LATEST master "E2E version for Kubernetes master" # testing against Kubernetes master is already tracking a moving target, so we might as well use a moving E2E version
 configvar CSI_PROW_E2E_REPO_LATEST https://github.com/kubernetes/kubernetes "E2E repo for Kubernetes >= 1.13.x" # currently the same for all versions
@@ -188,6 +222,10 @@ configvar CSI_PROW_SANITY_IMPORT_PATH github.com/kubernetes-csi/csi-test "csi-te
 configvar CSI_PROW_SANITY_SERVICE "hostpath-service" "Kubernetes TCP service name that exposes csi.sock"
 configvar CSI_PROW_SANITY_POD "csi-hostpathplugin-0" "Kubernetes pod with CSI driver"
 configvar CSI_PROW_SANITY_CONTAINER "hostpath" "Kubernetes container with CSI driver"
+
+# The version of dep to use for 'make test-vendor'. Ignored if the project doesn't
+# use dep. Only binary releases of dep are supported (https://github.com/golang/dep/releases).
+configvar CSI_PROW_DEP_VERSION v0.5.1 "golang dep version to be used for vendor checking"
 
 # Each job can run one or more of the following tests, identified by
 # a single word:
@@ -276,6 +314,7 @@ configvar CSI_PROW_E2E_ALPHA "$(get_versioned_variable CSI_PROW_E2E_ALPHA "${csi
 # it anymore for older releases.
 configvar CSI_PROW_E2E_ALPHA_GATES_1_13 'VolumeSnapshotDataSource=true,BlockVolume=true,CSIBlockVolume=true' "alpha feature gates for Kubernetes 1.13"
 configvar CSI_PROW_E2E_ALPHA_GATES_1_14 'VolumeSnapshotDataSource=true,ExpandCSIVolumes=true' "alpha feature gates for Kubernetes 1.14"
+configvar CSI_PROW_E2E_ALPHA_GATES_1_15 'VolumeSnapshotDataSource=true,ExpandCSIVolumes=true' "alpha feature gates for Kubernetes 1.15"
 # TODO: add new CSI_PROW_ALPHA_GATES_xxx entry for future Kubernetes releases and
 # add new gates to CSI_PROW_E2E_ALPHA_GATES_LATEST.
 configvar CSI_PROW_E2E_ALPHA_GATES_LATEST 'VolumeSnapshotDataSource=true,ExpandCSIVolumes=true' "alpha feature gates for latest Kubernetes"
@@ -287,7 +326,7 @@ configvar CSI_PROW_E2E_ALPHA_GATES "$(get_versioned_variable CSI_PROW_E2E_ALPHA_
 # whether they can run with the current cluster provider, but until
 # they are, we filter them out by name. Like the other test selection
 # variables, this is again a space separated list of regular expressions.
-configvar CSI_PROW_E2E_SKIP 'while.kubelet.is.down.*Disruptive' "tests that need to be skipped"
+configvar CSI_PROW_E2E_SKIP 'Disruptive' "tests that need to be skipped"
 
 # This is the directory for additional result files. Usually set by Prow, but
 # if not (for example, when invoking manually) it defaults to the work directory.
@@ -344,8 +383,8 @@ install_kind () {
     if run curl --fail --location -o "${CSI_PROW_WORK}/bin/kind" "https://github.com/kubernetes-sigs/kind/releases/download/${CSI_PROW_KIND_VERSION}/kind-linux-amd64"; then
         chmod u+x "${CSI_PROW_WORK}/bin/kind"
     else
-        git_checkout https://github.com/kubernetes-sigs/kind "$GOPATH/src/sigs.k8s.io/kind" "${CSI_PROW_KIND_VERSION}" --depth=1 &&
-        run_with_go "${CSI_PROW_GO_VERSION_KIND}" go build -o "${CSI_PROW_WORK}/bin/kind" sigs.k8s.io/kind
+        git_checkout https://github.com/kubernetes-sigs/kind "${GOPATH}/src/sigs.k8s.io/kind" "${CSI_PROW_KIND_VERSION}" --depth=1 &&
+        (cd "${GOPATH}/src/sigs.k8s.io/kind" && make install INSTALL_DIR="${CSI_PROW_WORK}/bin")
     fi
 }
 
@@ -359,6 +398,15 @@ install_ginkgo () {
     # We have to get dependencies and hence can't call just "go build".
     run_with_go "${CSI_PROW_GO_VERSION_GINKGO}" go get github.com/onsi/ginkgo/ginkgo || die "building ginkgo failed" &&
     mv "$GOPATH/bin/ginkgo" "${CSI_PROW_BIN}"
+}
+
+# Ensure that we have the desired version of dep.
+install_dep () {
+    if dep version 2>/dev/null | grep -q "version:.*${CSI_PROW_DEP_VERSION}$"; then
+        return
+    fi
+    run curl --fail --location -o "${CSI_PROW_WORK}/bin/dep" "https://github.com/golang/dep/releases/download/v0.5.4/dep-linux-amd64" &&
+        chmod u+x "${CSI_PROW_WORK}/bin/dep"
 }
 
 # This checks out a repo ("https://github.com/kubernetes/kubernetes")
@@ -387,6 +435,27 @@ git_checkout () {
         (cd "$path" && run git fetch "$repo" '+refs/heads/*:refs/remotes/csiprow/heads/*' '+refs/tags/*:refs/tags/*') || die "fetching $repo failed"
         (cd "$path" && run git checkout "$revision") || die "checking out $repo $revision failed"
     fi
+    # This is useful for local testing or when switching between different revisions in the same
+    # repo.
+    (cd "$path" && run git clean -fdx) || die "failed to clean $path"
+}
+
+# This clones a repo ("https://github.com/kubernetes/kubernetes")
+# in a certain location ("$GOPATH/src/k8s.io/kubernetes") at
+# a the head of a specific branch (i.e., release-1.13, master).
+# The directory cannot exist.
+git_clone_branch () {
+    local repo path branch parent
+    repo="$1"
+    shift
+    path="$1"
+    shift
+    branch="$1"
+    shift
+
+    parent="$(dirname "$path")"
+    mkdir -p "$parent"
+    (cd "$parent" && run git clone --single-branch --branch "$branch" "$repo" "$path") || die "cloning $repo" failed
     # This is useful for local testing or when switching between different revisions in the same
     # repo.
     (cd "$path" && run git clean -fdx) || die "failed to clean $path"
@@ -437,25 +506,10 @@ start_cluster () {
             if [ "$version" = "latest" ]; then
                 version=master
             fi
-            git_checkout https://github.com/kubernetes/kubernetes "$GOPATH/src/k8s.io/kubernetes" "$version" --depth=1 || die "checking out Kubernetes $version failed"
+            git_clone_branch https://github.com/kubernetes/kubernetes "${CSI_PROW_WORK}/src/kubernetes" "$version" || die "checking out Kubernetes $version failed"
 
-            # "kind build" and/or the Kubernetes build rules need at least one tag, which we don't have
-            # when doing a shallow fetch. Therefore we fake one:
-            # release-1.12 -> v1.12.0-release.<rev>.csiprow
-            # latest or <revision> -> v1.14.0-<rev>.csiprow
-            case "${CSI_PROW_KUBERNETES_VERSION}" in
-                release-*)
-                    # Ignore: See if you can use ${variable//search/replace} instead.
-                    # shellcheck disable=SC2001
-                    tag="$(echo "${CSI_PROW_KUBERNETES_VERSION}" | sed -e 's/release-\(.*\)/v\1.0-release./')";;
-                *)
-                    # We have to make something up. v1.0.0 did not work for some reasons.
-                    tag="v1.14.0-";;
-            esac
-            tag="$tag$(cd "$GOPATH/src/k8s.io/kubernetes" && git rev-list --abbrev-commit HEAD).csiprow"
-            (cd "$GOPATH/src/k8s.io/kubernetes" && run git tag -f "$tag") || die "git tag failed"
-            go_version="$(go_version_for_kubernetes "$GOPATH/src/k8s.io/kubernetes" "$version")" || die "cannot proceed without knowing Go version for Kubernetes"
-            run_with_go "$go_version" kind build node-image --type bazel --image csiprow/node:latest --kube-root "$GOPATH/src/k8s.io/kubernetes" || die "'kind build node-image' failed"
+            go_version="$(go_version_for_kubernetes "${CSI_PROW_WORK}/src/kubernetes" "$version")" || die "cannot proceed without knowing Go version for Kubernetes"
+            run_with_go "$go_version" kind build node-image --type bazel --image csiprow/node:latest --kube-root "${CSI_PROW_WORK}/src/kubernetes" || die "'kind build node-image' failed"
             csi_prow_kind_have_kubernetes=true
         fi
         image="csiprow/node:latest"
@@ -463,40 +517,52 @@ start_cluster () {
         image="kindest/node:v${CSI_PROW_KUBERNETES_VERSION}"
     fi
     cat >"${CSI_PROW_WORK}/kind-config.yaml" <<EOF
-kind: Config
-apiVersion: kind.sigs.k8s.io/v1alpha2
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
 nodes:
 - role: control-plane
-  kubeadmConfigPatches:
-  - |
-    apiVersion: kubeadm.k8s.io/v1beta1
-    kind: ClusterConfiguration
-    metadata:
-      name: config
-    apiServer:
-      extraArgs:
-        "feature-gates": "$gates"
-    controllerManager:
-      extraArgs:
-        "feature-gates": "$gates"
-    scheduler:
-      extraArgs:
-        "feature-gates": "$gates"
-  - |
-    apiVersion: kubelet.config.k8s.io/v1beta1
-    kind: KubeletConfiguration
-    metadata:
-      name: config
-    featureGates:
-$(list_gates "$gates")
-  - |
-    apiVersion: kubeproxy.config.k8s.io/v1alpha1
-    kind: KubeProxyConfiguration
-    metadata:
-      name: config
-    featureGates:
+- role: worker
+EOF
+
+    # kubeadm has API dependencies between apiVersion and Kubernetes version
+    # 1.15+ requires kubeadm.k8s.io/v1beta2
+    # We only run alpha tests against master so we don't need to maintain
+    # different patches for different Kubernetes releases.
+    if [[ -n "$gates" ]]; then
+        cat >>"${CSI_PROW_WORK}/kind-config.yaml" <<EOF
+kubeadmConfigPatches:
+- |
+  apiVersion: kubeadm.k8s.io/v1beta2
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  apiServer:
+    extraArgs:
+      "feature-gates": "$gates"
+  controllerManager:
+    extraArgs:
+      "feature-gates": "$gates"
+  scheduler:
+    extraArgs:
+      "feature-gates": "$gates"
+- |
+  apiVersion: kubeadm.k8s.io/v1beta2
+  kind: InitConfiguration
+  metadata:
+    name: config
+  nodeRegistration:
+    kubeletExtraArgs:
+      "feature-gates": "$gates"
+- |
+  apiVersion: kubeproxy.config.k8s.io/v1alpha1
+  kind: KubeProxyConfiguration
+  metadata:
+    name: config
+  featureGates:
 $(list_gates "$gates")
 EOF
+    fi
+
     info "kind-config.yaml:"
     cat "${CSI_PROW_WORK}/kind-config.yaml"
     if ! run kind create cluster --name csi-prow --config "${CSI_PROW_WORK}/kind-config.yaml" --wait 5m --image "$image"; then
@@ -673,6 +739,29 @@ hostpath_supports_block () {
     echo "${result:-true}"
 }
 
+# The default implementation of this function generates a external
+# driver test configuration for the hostpath driver.
+#
+# The content depends on both what the E2E suite expects and what the
+# installed hostpath driver supports. Generating it here seems prone
+# to breakage, but it is uncertain where a better place might be.
+generate_test_driver () {
+    cat <<EOF
+ShortName: csiprow
+StorageClass:
+  FromName: true
+SnapshotClass:
+  FromName: true
+DriverInfo:
+  Name: ${CSI_PROW_HOSTPATH_DRIVER_NAME}
+  Capabilities:
+    block: $(hostpath_supports_block)
+    persistence: true
+    dataSource: true
+    multipods: true
+EOF
+}
+
 # Captures pod output while running some other command.
 run_with_loggers () (
     loggers=$(start_loggers -f)
@@ -698,23 +787,7 @@ run_e2e () (
     # When running on a multi-node cluster, we need to figure out where the
     # hostpath driver was deployed and set ClientNodeName accordingly.
 
-    # The content of this file depends on both what the E2E suite expects and
-    # what the installed hostpath driver supports. Generating it here seems
-    # prone to breakage, but it is uncertain where a better place might be.
-    cat >"${CSI_PROW_WORK}/hostpath-test-driver.yaml" <<EOF
-ShortName: csiprow
-StorageClass:
-  FromName: true
-SnapshotClass:
-  FromName: true
-DriverInfo:
-  Name: csi-hostpath
-  Capabilities:
-    block: $(hostpath_supports_block)
-    persistence: true
-    dataSource: true
-    multipods: true
-EOF
+    generate_test_driver >"${CSI_PROW_WORK}/test-driver.yaml" || die "generating test-driver.yaml failed"
 
     # Rename, merge and filter JUnit files. Necessary in case that we run the E2E suite again
     # and to avoid the large number of "skipped" tests that we get from using
@@ -727,7 +800,7 @@ EOF
     trap move_junit EXIT
 
     cd "${GOPATH}/src/${CSI_PROW_E2E_IMPORT_PATH}" &&
-    run_with_loggers ginkgo -v "$@" "${CSI_PROW_WORK}/e2e.test" -- -report-dir "${ARTIFACTS}" -storage.testdriver="${CSI_PROW_WORK}/hostpath-test-driver.yaml"
+    run_with_loggers ginkgo -v "$@" "${CSI_PROW_WORK}/e2e.test" -- -report-dir "${ARTIFACTS}" -storage.testdriver="${CSI_PROW_WORK}/test-driver.yaml"
 )
 
 # Run csi-sanity against installed CSI driver.
@@ -877,6 +950,10 @@ main () {
         # changes in "release-tools" in a PR (that fails the "is release-tools unmodified"
         # test).
         if tests_enabled "unit"; then
+            if [ -f Gopkg.toml ] && ! install_dep; then
+                warn "installing 'dep' failed, cannot test vendoring"
+                ret=1
+            fi
             if ! run_with_go "${CSI_PROW_GO_VERSION_BUILD}" make -k test 2>&1 | make_test_to_junit; then
                 warn "'make test' failed, proceeding anyway"
                 ret=1

--- a/release-tools/travis.yml
+++ b/release-tools/travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 matrix:
   include:
-  - go: 1.11.1
+  - go: 1.12.4
 before_script:
 - mkdir -p bin
 - wget https://github.com/golang/dep/releases/download/v0.5.1/dep-linux-amd64 -O bin/dep


### PR DESCRIPTION
\+ bump golang to 1.12 in OpenShift images

diff to upstream v1.2.0: https://github.com/kubernetes-csi/node-driver-registrar/compare/v1.2.0...jsafrane:rebase-1.2.0