### PR TITLE
OCPBUGS-27242: fix or ignore snyk errors for ocp storage repos

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,4 @@
 exclude:
   global:
     - vendor/**
+    - release-tools/**


### PR DESCRIPTION
Ignore these errors, release-tools is not part of the component that runs in production, and these reported issues do not grant the caller any extra permissions. If you can read it with release-tools then you already have access to read it without release-tools.

```
 ✗ [Medium] Path Traversal
   ID: af243e66-4149-4c0d-af0b-0e4bbadad3ba 
   Path: release-tools/filter-junit.go, line 98 
   Info: Unsanitized input from a CLI argument flows into os.ReadFile, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
 ✗ [Medium] Path Traversal
   ID: d630bedb-d091-432a-96d6-6f41c7b121f7 
   Path: release-tools/filter-junit.go, line 145 
   Info: Unsanitized input from a CLI argument flows into os.WriteFile, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to write arbitrary files.
 ✗ [Medium] Path Traversal
   ID: 50bd95de-2932-4823-9a67-b266150f9b15 
   Path: release-tools/boilerplate/boilerplate.py, line 59 
   Info: Unsanitized input from a command line argument flows into open, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
 ✗ [Medium] Path Traversal
   ID: 740c0431-90ee-452b-b869-cbf48ac2a285 
   Path: release-tools/boilerplate/boilerplate.py, line 150 
   Info: Unsanitized input from a command line argument flows into os.walk, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
```

from https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/47618/rehearse-47618-pull-ci-openshift-csi-node-driver-registrar-master-security/1745954197615939584

/cc @openshift/storage
