### PR TITLE
OCPBUGS-60108: update log level verbosity to not clutter logs

### DIFF
--- a/cmd/csi-node-driver-registrar/main.go
+++ b/cmd/csi-node-driver-registrar/main.go
@@ -94,7 +94,7 @@ func newRegistrationServer(driverName string, endpoint string, versions []string
 // GetInfo is the RPC invoked by plugin watcher
 func (e registrationServer) GetInfo(ctx context.Context, req *registerapi.InfoRequest) (*registerapi.PluginInfo, error) {
 	logger := klog.FromContext(ctx)
-	logger.Info("Received GetInfo call", "request", req)
+	logger.V(4).Info("Received GetInfo call", "request", req)
 
 	return &registerapi.PluginInfo{
 		Type:              registerapi.CSIPlugin,

--- a/cmd/csi-node-driver-registrar/node_register.go
+++ b/cmd/csi-node-driver-registrar/node_register.go
@@ -141,7 +141,7 @@ func httpServer(ctx context.Context, socketPath string, httpEndpoint string, csi
 
 func checkLiveRegistrationSocket(ctx context.Context, socketFile, csiDriverName string) error {
 	logger := klog.FromContext(ctx)
-	logger.V(2).Info("Attempting to open a gRPC connection", "socketfile", socketFile)
+	logger.V(4).Info("Attempting to open a gRPC connection", "socketfile", socketFile)
 	grpcConn, err := connection.ConnectWithoutMetrics(ctx, socketFile)
 	if err != nil {
 		return fmt.Errorf("error connecting to node-registrar socket %s: %v", socketFile, err)
@@ -149,7 +149,7 @@ func checkLiveRegistrationSocket(ctx context.Context, socketFile, csiDriverName 
 
 	defer closeGrpcConnection(logger, socketFile, grpcConn)
 
-	logger.V(2).Info("Calling node registrar to check if it still responds")
+	logger.V(4).Info("Calling node registrar to check if it still responds")
 	ctx, cancel := context.WithTimeout(context.Background(), *operationTimeout)
 	defer cancel()
 


### PR DESCRIPTION
cherry-pick of https://github.com/kubernetes-csi/node-driver-registrar/pull/533

cc @openshift/storage 