### PR TITLE
OCPBUGS-83863: Strip debug symbols from Go binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,6 @@ CMDS=csi-node-driver-registrar
 all: build
 
 include release-tools/build.make
+LDFLAGS = -s -w
 
 test: test-logcheck


### PR DESCRIPTION
## Summary
- Set `LDFLAGS = -s -w` in `Makefile` after including `release-tools/build.make` to strip DWARF debug info and symbol tables

## Impact
The csi-node-driver-registrar image (310 MB) contains one unstripped Go binary:
- `csi-node-driver-registrar` (26.7 MB)

Stripping typically reduces Go binary size by 20-30%, reducing container image pull time during node scale-up.

## Test plan
- [ ] Verify image builds successfully
- [ ] Verify binary is stripped
- [ ] Verify csi-node-driver-registrar functions correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration for improved binary size and startup performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->