### PR TITLE
OCPBUGS-84436: Bump github.com/moby/spdystream to v0.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -137,3 +137,6 @@ replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.35.0
 replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.35.0
 
 replace k8s.io/sample-controller => k8s.io/sample-controller v0.35.0
+
+// CVE-2026-35469
+replace github.com/moby/spdystream => github.com/moby/spdystream v0.5.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -455,3 +455,4 @@ sigs.k8s.io/structured-merge-diff/v6/value
 # k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.35.0
 # k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.35.0
 # k8s.io/sample-controller => k8s.io/sample-controller v0.35.0
+# github.com/moby/spdystream => github.com/moby/spdystream v0.5.1


### PR DESCRIPTION
## Summary

Fixes CVE-2026-35469 by updating github.com/moby/spdystream from v0.5.0 to v0.5.1.

## CVE Details

**CVE-2026-35469**: Denial of Service via SPDY streaming code

- **Severity**: High  
- **Affected**: github.com/moby/spdystream < v0.5.1  
- **Impact**: Possible DOS in SPDY streaming code used for attach, exec and port forwarding  

## Changes

- Added replace directive: `github.com/moby/spdystream => github.com/moby/spdystream v0.5.1`
- Updated vendor/modules.txt
- **Minimal change**: 2 files, 4 insertions

## Why Replace Directive?

The spdystream module is a **transitive dependency** through k8s.io/client-go and k8s.io/kubelet:
- k8s.io/client-go@v0.35.0 → github.com/moby/spdystream@v0.5.0 (vulnerable)
- k8s.io/kubelet@v0.35.0 → github.com/moby/spdystream@v0.5.0 (vulnerable)

Since we cannot upgrade k8s.io from v0.35.0 to v0.36.1 on a stable release branch, we use a replace directive to override the transitive dependency.

## Upstream Status

**Upstream already fixed** via k8s.io v0.36.1:
- Upstream repo: https://github.com/kubernetes-csi/node-driver-registrar
- Upstream uses: k8s.io/client-go@v0.36.1 → spdystream@v0.5.1 ✅
- No upstream PR needed (already resolved via k8s.io upgrade)
